### PR TITLE
Add build badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # MTB_scoring
+
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/MobileToolbox/MTB_scoring/docker-image.yml?label=build%20Docker%20image)](https://github.com/MobileToolbox/MTB_scoring/actions/workflows/docker-image.yml)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/MobileToolbox/MTB_scoring/pytest.yml?label=pytest)](https://github.com/MobileToolbox/MTB_scoring/actions/workflows/pytest.yml)
+
 Code for scoring Mobile Toolbox measures

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MTB_scoring
 
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/MobileToolbox/MTB_scoring/docker-image.yml?label=build%20Docker%20image)](https://github.com/MobileToolbox/MTB_scoring/actions/workflows/docker-image.yml)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/MobileToolbox/MTB_scoring/docker-image.yml?label=build%20docker%20image)](https://github.com/MobileToolbox/MTB_scoring/actions/workflows/docker-image.yml)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/MobileToolbox/MTB_scoring/pytest.yml?label=pytest)](https://github.com/MobileToolbox/MTB_scoring/actions/workflows/pytest.yml)
 
 Code for scoring Mobile Toolbox measures


### PR DESCRIPTION
Add build badges to README.md for quick access to build status of docker-build and pytest workflows